### PR TITLE
Fixed Unicode support and updated README tempaltes to support role names with hyphen.

### DIFF
--- a/ansigenome/data/README.md.j2
+++ b/ansigenome/data/README.md.j2
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block badges %}
-{% if ansigenome_info.travis is defined and ansigenome_info.travis %}[![Travis CI](http://img.shields.io/travis/{{ scm.user + '/' + role.slug }}.svg?style=flat)](http://travis-ci.org/{{ scm.user + '/' + role.slug }}){% endif %} {% if ansigenome_info.galaxy_id is defined and ansigenome_info.galaxy_id %} [![Ansible Galaxy](http://img.shields.io/badge/galaxy-{{ role.galaxy_name }}-660198.svg?style=flat)](https://galaxy.ansible.com/list#/roles/{{ ansigenome_info.galaxy_id }}){% endif %}{% if galaxy_info.platforms is defined and galaxy_info.platforms %} [![Platforms](http://img.shields.io/badge/platforms-{{ galaxy_info.platforms | map(attribute='name') | sort | join('%20/%20') | lower }}-lightgrey.svg?style=flat)](#){% endif %}
+{% if ansigenome_info.travis is defined and ansigenome_info.travis %}[![Travis CI](http://img.shields.io/travis/{{ scm.user + '/' + role.slug }}.svg?style=flat)](http://travis-ci.org/{{ scm.user + '/' + role.slug }}){% endif %} {% if ansigenome_info.galaxy_id is defined and ansigenome_info.galaxy_id %} [![Ansible Galaxy](http://img.shields.io/badge/galaxy-{{ role.galaxy_name | replace('-', '–')}}-660198.svg?style=flat)](https://galaxy.ansible.com/list#/roles/{{ ansigenome_info.galaxy_id }}){% endif %}{% if galaxy_info.platforms is defined and galaxy_info.platforms %} [![Platforms](http://img.shields.io/badge/platforms-{{ galaxy_info.platforms | map(attribute='name') | sort | join('%20/%20') | lower }}-lightgrey.svg?style=flat)](#){% endif %}
 {% endblock %}
 
 {% if ansigenome_info.beta is defined and ansigenome_info.beta %}

--- a/ansigenome/data/README.rst.j2
+++ b/ansigenome/data/README.rst.j2
@@ -3,7 +3,7 @@
 
 {% block title %}
 {{ role.name }}
-{{ "=" * title_length }} 
+{{ "=" * title_length }}
 {% endblock %}
 
 {% block badges %}
@@ -12,9 +12,9 @@
 {% if ansigenome_info.travis is defined and ansigenome_info.travis %}
 .. |Travis CI| image:: http://img.shields.io/travis/{{ scm.user + '/' + role.slug }}.svg?style=flat
    :target: http://travis-ci.org/{{ scm.user + '/' + role.slug }}
-{% endif %} 
+{% endif %}
 {% if ansigenome_info.galaxy_id is defined and ansigenome_info.galaxy_id %}
-.. |Ansible Galaxy| image:: http://img.shields.io/badge/galaxy-{{ role.galaxy_name }}-660198.svg?style=flat
+.. |Ansible Galaxy| image:: http://img.shields.io/badge/galaxy-{{ role.galaxy_name | replace('-', '–')}}-660198.svg?style=flat
    :target: https://galaxy.ansible.com/list#/roles/{{ ansigenome_info.galaxy_id }}
 {% endif %}
 {% if galaxy_info.platforms is defined and galaxy_info.platforms %}

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -1,3 +1,4 @@
+import codecs
 import errno
 import json
 import os
@@ -45,7 +46,7 @@ def string_to_file(path, input):
     """
     mkdir_p(os.path.dirname(path))
 
-    with open(path, "w+") as file:
+    with codecs.open(path, "w+", "UTF-8") as file:
         file.write(input)
 
 
@@ -57,7 +58,7 @@ def file_to_string(path):
         ui.error(c.MESSAGES["path_missing"], path)
         sys.exit(1)
 
-    with open(path, "r") as contents:
+    with codecs.open(path, "r", "UTF-8") as contents:
         return contents.read()
 
 
@@ -69,7 +70,7 @@ def file_to_list(path):
         ui.error(c.MESSAGES["path_missing"], path)
         sys.exit(1)
 
-    with open(path, "r") as contents:
+    with codecs.open(path, "r", "UTF-8") as contents:
         lines = contents.read().splitlines()
 
     return lines
@@ -130,7 +131,7 @@ def template(path, extend_path, out):
         env.filters["unique_dict"] = unique_dict
 
         # create a dictionary of templates
-        templates = dict((name, open(name, "rb").read()) for name in files)
+        templates = dict((name, codecs.open(name, "rb", 'UTF-8').read()) for name in files)
         env.loader = DictLoader(templates)
 
         # return the final result (the last template in the list)

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -131,7 +131,9 @@ def template(path, extend_path, out):
         env.filters["unique_dict"] = unique_dict
 
         # create a dictionary of templates
-        templates = dict((name, codecs.open(name, "rb", 'UTF-8').read()) for name in files)
+        templates = dict(
+            (name, codecs.open(name, "rb", 'UTF-8').read())
+            for name in files)
         env.loader = DictLoader(templates)
 
         # return the final result (the last template in the list)


### PR DESCRIPTION
Was needed for ansible roles with hyphen because shields.io does not seem to support them:

* With [hyphen](https://en.wikipedia.org/wiki/Hyphen): http://img.shields.io/badge/galaxy-ypid.udev-usbmon-660198.svg?style=flat
* With [En-Dash](https://en.wikipedia.org/wiki/Dash#En_dash) http://img.shields.io/badge/galaxy-ypid.udev–usbmon-660198.svg?style=flat
