### PR TITLE
Allow String values in roles

### DIFF
--- a/ansigenome/scan.py
+++ b/ansigenome/scan.py
@@ -210,7 +210,10 @@ class Scan(object):
             dep_list = []
 
             for dependency in meta_dict["dependencies"]:
-                dep_list.append(dependency["role"])
+                if type(dependency) is dict:
+                    dep_list.append(dependency["role"])
+                else:
+                    dep_list.append(dependency)
 
             # unique set of dependencies
             meta_dict["dependencies"] = list(set(dep_list))


### PR DESCRIPTION
The current implementation of the scan command only allows role dependencies described with dict, such as

```yaml
dependencies:
  - { role: common, version: 1.0 }
```
but dependencies can also be simple string, such as
```yaml
dependencies:
  - common
```

This patch fix the TypeError exception raised when using string dependencies. 