### PR TITLE
Do not load yaml from empty path

### DIFF
--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -189,7 +189,7 @@ def yaml_load(path, input="", err_quit=False):
     try:
         if len(input) > 0:
             return yaml.load(input)
-        else:
+        elif len(path) > 0:
             return yaml.load(file_to_string(path))
     except Exception as err:
         file = os.path.basename(path)


### PR DESCRIPTION
While executing the "export" command, I faced the error: "The following path could not be found:"  because one of my defaults file was empty.

This patch just ensured we don't load yaml from a file if the path is empty