### PR TITLE
Allow roles with a '-' in their name

### DIFF
--- a/ansigenome/export.py
+++ b/ansigenome/export.py
@@ -136,7 +136,8 @@ digraph role_dependencies {
                 for dependency in sorted(fields["dependencies"]):
                     dependency_name = utils.role_name(dependency)
                     dependencies += "        role_{0} -> role_{1}\n" \
-                                    .format(name, dependency_name)
+                                    .format(name, utils.normalize_role(
+                                            dependency_name, self.config))
 
                 edges += "{0}{1}\n".format(edge, dependencies)
 

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -351,7 +351,7 @@ def normalize_role(role, config):
         else:
             role_name = role
 
-    return role_name
+    return role_name.replace("-", "_")
 
 
 def create_meta_main(create_path, config, role, categories):


### PR DESCRIPTION
This patch normalize role names and dependencies names to remove all '-' char and replace it with '_'

the '-' char causes dot to fail with the following message:
```
Warning: <stdin>: syntax error in line 18 near '-'
```

It's only a warning but the export fails anyway