### PR TITLE
Enable syntax highlighting for defaults/main.yml file.

### DIFF
--- a/ansigenome/data/README.md.j2
+++ b/ansigenome/data/README.md.j2
@@ -32,7 +32,9 @@ in a production environment.
 
 This role requires at least Ansible{% if galaxy_info.min_ansible_version is defined and galaxy_info.min_ansible_version %} `v{{ galaxy_info.min_ansible_version }}`{% endif %}. To install it, run:
 
-    ansible-galaxy install {{ role.galaxy_name }}
+```Shell
+ansible-galaxy install {{ role.galaxy_name }}
+```
 {% endblock %}
 {% endif %}
 
@@ -51,7 +53,9 @@ This role requires at least Ansible{% if galaxy_info.min_ansible_version is defi
 
 List of default variables available in the inventory:
 
-{{ ansigenome_info.defaults | trim | indent(4, true) }}
+```YAML
+{{ ansigenome_info.defaults | trim }}
+```
 {% endif %}
 
 {% if ansigenome_info.facts is defined and ansigenome_info.facts %}


### PR DESCRIPTION
* Also specific command as shell command.
* Refer to https://github.com/github/linguist/blob/master/lib/linguist/languages.yml

* Examples:
  * Without highlighting: https://github.com/ypid/ansible-linuxmuster_net-server-epoptes_via_postsync/tree/7d68cb3c5f32c5c6e067569fc8cdb229d3a2df0d#role-variables
  * With highlighting: https://github.com/ypid/ansible-linuxmuster_net-server-epoptes_via_postsync/tree/31ca9645f1627d9cdb816f89382e843c4c31d35f#role-variables