### PR TITLE
Updated role URLs as used by Ansible Galaxy >= 1.1.0.

### DIFF
--- a/ansigenome/data/README.md.j2
+++ b/ansigenome/data/README.md.j2
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block badges %}
-{% if ansigenome_info.travis is defined and ansigenome_info.travis %}[![Travis CI](http://img.shields.io/travis/{{ scm.user + '/' + role.slug }}.svg?style=flat)](http://travis-ci.org/{{ scm.user + '/' + role.slug }}){% endif %} {% if ansigenome_info.galaxy_id is defined and ansigenome_info.galaxy_id %} [![Ansible Galaxy](http://img.shields.io/badge/galaxy-{{ role.galaxy_name | replace('-', '–')}}-660198.svg?style=flat)](https://galaxy.ansible.com/list#/roles/{{ ansigenome_info.galaxy_id }}){% endif %}{% if galaxy_info.platforms is defined and galaxy_info.platforms %} [![Platforms](http://img.shields.io/badge/platforms-{{ galaxy_info.platforms | map(attribute='name') | sort | join('%20/%20') | lower }}-lightgrey.svg?style=flat)](#){% endif %}
+{% if ansigenome_info.travis is defined and ansigenome_info.travis %}[![Travis CI](http://img.shields.io/travis/{{ scm.user + '/' + role.slug }}.svg?style=flat)](http://travis-ci.org/{{ scm.user + '/' + role.slug }}){% endif %} {% if ansigenome_info.galaxy_id is defined and ansigenome_info.galaxy_id %} [![Ansible Galaxy](http://img.shields.io/badge/galaxy-{{ role.galaxy_name | replace('-', '–')}}-660198.svg?style=flat)](https://galaxy.ansible.com/detail#/role/{{ ansigenome_info.galaxy_id }}){% endif %}{% if galaxy_info.platforms is defined and galaxy_info.platforms %} [![Platforms](http://img.shields.io/badge/platforms-{{ galaxy_info.platforms | map(attribute='name') | sort | join('%20/%20') | lower }}-lightgrey.svg?style=flat)](#){% endif %}
 {% endblock %}
 
 {% if ansigenome_info.beta is defined and ansigenome_info.beta %}

--- a/ansigenome/data/README.rst.j2
+++ b/ansigenome/data/README.rst.j2
@@ -20,7 +20,7 @@
 {% endif %}
 {% if ansigenome_info.galaxy_id is defined and ansigenome_info.galaxy_id %}
 .. |Ansible Galaxy| image:: http://img.shields.io/badge/galaxy-{{ role.galaxy_name | replace('-', '–')}}-660198.svg?style=flat
-   :target: https://galaxy.ansible.com/list#/roles/{{ ansigenome_info.galaxy_id }}
+   :target: https://galaxy.ansible.com/detail#/role/{{ ansigenome_info.galaxy_id }}
 {% endif %}
 {% if galaxy_info.platforms is defined and galaxy_info.platforms %}
 .. |Platforms| image:: http://img.shields.io/badge/platforms-{{ galaxy_info.platforms | map(attribute='name') | sort | join('%20|%20') | lower }}-lightgrey.svg?style=flat


### PR DESCRIPTION
* 1.1.0 broke the old role permalink.
* 1.1.1 Galaxy now redirects to the new permalink.
  https://github.com/ansible/galaxy-issues/issues/89

Related to
https://github.com/drybjed/debops/commit/728ec857d6a11b74bd14c4276ea8a99a70ee5a39?short_path=db23dcd#diff-e8d5f96dda10d00be9bf1e32a0732191R24