### PR TITLE
Fixed line break for multiple role dependencies.

### DIFF
--- a/ansigenome/data/README.md.j2
+++ b/ansigenome/data/README.md.j2
@@ -47,7 +47,8 @@ ansible-galaxy install {{ role.galaxy_name }}
 ### Role dependencies
 
 {% for dependency in dependencies | unique_dict("role") %}
-- `{{ dependency.role | trim }}`{% endfor %}
+- `{{ dependency.role | trim }}`
+{% endfor %}
 {% endblock %}
 {% endif %}
 


### PR DESCRIPTION
* Fixed in DebOps: https://github.com/debops/debops/blob/4efb22d522690cb4a2c478caaa5aa616e42fb3a8/misc/ansigenome/templates/DebOps-README.md.j2#L38-L39

Why was this not fixed upstream?

Before: https://github.com/ypid/ansible-foodsoft/tree/be32e7b7579d8d1ce358a974eec7d75fe800140e#role-dependencies
After: https://github.com/ypid/ansible-foodsoft/tree/fda5188853e5ba9107354601c957286f11d2a39b#role-dependencies