### PR TITLE
Added line break in authors and license section to look nice on Ansible Galaxy.

### DIFF
--- a/ansigenome/data/README.md.j2
+++ b/ansigenome/data/README.md.j2
@@ -89,6 +89,7 @@ List of internal variables used by the role:
 ### Authors and license
 
 `{{ role.name }}` role was written by:
+
 {% for credit in authors %}
 - {% if credit.url is defined and credit.url %}[{% endif %}{{ credit.name }}{% if credit.url is defined and credit.url %}]({{ credit.url }}){% endif %}{% if credit.email is defined and credit.email %} | [e-mail](mailto:{{ credit.email }}){% endif %}{% if credit.twitter is defined and credit.twitter %} | [Twitter](https://twitter.com/{{ credit.twitter }}){% endif %}{% if credit.github is defined and credit.github %} | [GitHub](https://github.com/{{ credit.github }}){% endif %}
 


### PR DESCRIPTION
* GitHub did prior to this change add a newline by there Markdown
  parser.

### Before

![screenshot from 2015-11-10 19 21 35](https://cloud.githubusercontent.com/assets/1301158/11071314/81f2a0aa-87e0-11e5-8ae3-0f8c5769c808.png)

### After

![screenshot from 2015-11-10 19 24 14](https://cloud.githubusercontent.com/assets/1301158/11071352/bb7f8612-87e0-11e5-84c5-48c4af23552d.png)

https://github.com/ypid/ansible-initramfs_message