### PR TITLE
Do not sort/mix the order of role dependencies.

### DIFF
--- a/ansigenome/data/README.md.j2
+++ b/ansigenome/data/README.md.j2
@@ -47,8 +47,8 @@ ansible-galaxy install {{ role.galaxy_name }}
 {% block dependencies %}
 ### Role dependencies
 
-{% for dependency in dependencies | unique_dict("role") %}
-- `{{ dependency.role | trim }}`
+{% for role_dependency_name in dependencies | map(attribute='role') | unique %}
+- `{{ role_dependency_name | trim }}`
 {% endfor %}
 {% endblock %}
 {% endif %}

--- a/ansigenome/data/README.rst.j2
+++ b/ansigenome/data/README.rst.j2
@@ -65,8 +65,8 @@ This role requires at least Ansible{% if galaxy_info.min_ansible_version is defi
 Role dependencies
 ~~~~~~~~~~~~~~~~~
 
-{% for dependency in dependencies | unique_dict("role") %}
-- ``{{ dependency.role | trim }}``
+{% for role_dependency_name in dependencies | map(attribute='role') | unique %}
+- ``{{ role_dependency_name | trim }}``
 {% endfor %}
 {% endblock %}
 {% endif %}

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -131,9 +131,8 @@ def template(path, extend_path, out):
         env = RelEnvironment(trim_blocks=True)
 
         # Add a unique dict filter, by key.
-        # Try to use normal filters as known from Jinja and Ansible instead of
-        # this custom one. This filter is included in Ansigenome for backwards
-        # compatibility reasons.
+        # DEPRECATION WARNING: This is only used for backwards compatibility,
+        #                      please use the unique filter instead.
         def unique_dict(items, key):
             return {v[key]: v for v in items}.values()
 
@@ -141,7 +140,9 @@ def template(path, extend_path, out):
 
         def unique(a):
 
-            # Don’t use that in Ansigenome as it resorts the role dependencies.
+            # Don’t use the following commented out optimization which is used
+            # in ansible/lib/ansible/plugins/filter/mathstuff.py in Ansigenome
+            # as it resorts the role dependencies:
             # if isinstance(a,collections.Hashable):
             #     c = set(a)
 

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import codecs
 import errno
 import json
@@ -6,6 +8,7 @@ import re
 import subprocess
 import urllib2
 import yaml
+#  import collections
 
 import sys
 reload(sys)
@@ -127,11 +130,28 @@ def template(path, extend_path, out):
         # Use the subclassed relative environment class
         env = RelEnvironment(trim_blocks=True)
 
-        # Add a unique dict filter, by key
+        # Add a unique dict filter, by key.
+        # Try to use normal filters as known from Jinja and Ansible instead of
+        # this custom one. This filter is included in Ansigenome for backwards
+        # compatibility reasons.
         def unique_dict(items, key):
             return {v[key]: v for v in items}.values()
 
         env.filters["unique_dict"] = unique_dict
+
+        def unique(a):
+
+            # Don’t use that in Ansigenome as it resorts the role dependencies.
+            # if isinstance(a,collections.Hashable):
+            #     c = set(a)
+
+            c = []
+            for x in a:
+                if x not in c:
+                    c.append(x)
+            return c
+
+        env.filters["unique"] = unique
 
         # create a dictionary of templates
         templates = dict(


### PR DESCRIPTION
It is expected that the order of role dependencies has at least some
meaning so that the sorting applied by the author of the role is more important than
sorting by Ansigenome or as it was done before this commit by applying
a kind of random order (dict data structure sorting) to it.

Also use a more Ansible`ish` Jinja2 by using common filters from Jinja2
`map` and a custom one from Ansible `unique`.

BTW. `return {v[key]: v for v in items}.values()` is an interesting way to do it :+1: