### PR TITLE
Allow hyphens in role names and added '.' forbidden char in dot language.

### DIFF
--- a/ansigenome/export.py
+++ b/ansigenome/export.py
@@ -1,6 +1,7 @@
 import os
 import random
 import sys
+import re
 
 import constants as c
 import ui as ui
@@ -124,7 +125,7 @@ digraph role_dependencies {
 
             random_index = random.randint(1, color_length)
             roles_list += "        role_{0}              [label = \"{0}\"]\n" \
-                          .format(name)
+                          .format(re.sub(r'[.-]', '_', name))
 
             edge = '\n        edge [color = "{0}"];\n' \
                    .format(adjusted_colors[random_index])
@@ -135,9 +136,10 @@ digraph role_dependencies {
 
                 for dependency in sorted(fields["dependencies"]):
                     dependency_name = utils.role_name(dependency)
-                    dependencies += "        role_{0} -> role_{1}\n" \
-                                    .format(name, utils.normalize_role(
-                                            dependency_name, self.config))
+                    dependencies += "        role_{0} -> role_{1}\n".format(
+                        re.sub(r'[.-]', '_', name),
+                        utils.normalize_role(dependency_name, self.config)
+                    )
 
                 edges += "{0}{1}\n".format(edge, dependencies)
 

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -375,7 +375,13 @@ def normalize_role(role, config):
         else:
             role_name = role
 
-    return role_name.replace("-", "_")
+    # It is not recommended to use hyphen in role names (see
+    # https://github.com/nickjj/ansigenome/pull/19#issuecomment-75597850) But
+    # when you know what you are doing they can be used and are valid as far as
+    # Ansible Galaxy is concerned.
+    #  role_name = role_name.replace("-", "_")
+
+    return role_name
 
 
 def create_meta_main(create_path, config, role, categories):


### PR DESCRIPTION
Provides a better fix for the problem than:
https://github.com/nickjj/ansigenome/commit/5f83abaddbb1cc91d7db3d6b66a0b0f70af1c7db