### PR TITLE
Allow ansigenome to scan role with sub dir

### DIFF
--- a/ansigenome/export.py
+++ b/ansigenome/export.py
@@ -138,7 +138,10 @@ digraph role_dependencies {
                     dependency_name = utils.role_name(dependency)
                     dependencies += "        role_{0} -> role_{1}\n".format(
                         re.sub(r'[.-/]', '_', name),
-                        re.sub(r'[.-/]', '_', utils.normalize_role(dependency_name, self.config))
+                        re.sub(r'[.-/]', '_',
+                               utils.normalize_role(dependency_name,
+                                                    self.config)
+                               )
                     )
 
                 edges += "{0}{1}\n".format(edge, dependencies)

--- a/ansigenome/export.py
+++ b/ansigenome/export.py
@@ -124,8 +124,8 @@ digraph role_dependencies {
                 color_length = len(adjusted_colors) - 1
 
             random_index = random.randint(1, color_length)
-            roles_list += "        role_{0}              [label = \"{0}\"]\n" \
-                          .format(re.sub(r'[.-]', '_', name))
+            roles_list += "        role_{0}              [label = \"{1}\"]\n" \
+                          .format(re.sub(r'[.-/]', '_', name), name)
 
             edge = '\n        edge [color = "{0}"];\n' \
                    .format(adjusted_colors[random_index])
@@ -137,8 +137,8 @@ digraph role_dependencies {
                 for dependency in sorted(fields["dependencies"]):
                     dependency_name = utils.role_name(dependency)
                     dependencies += "        role_{0} -> role_{1}\n".format(
-                        re.sub(r'[.-]', '_', name),
-                        utils.normalize_role(dependency_name, self.config)
+                        re.sub(r'[.-/]', '_', name),
+                        re.sub(r'[.-/]', '_', utils.normalize_role(dependency_name, self.config))
                     )
 
                 edges += "{0}{1}\n".format(edge, dependencies)

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -309,7 +309,7 @@ def exit_if_no_roles(roles_count, roles_path):
         sys.exit()
 
 
-def roles_dict(path, repo_prefix=""):
+def roles_dict(path, repo_prefix="", repo_sub_dir=""):
     """
     Return a dict of role names and repo paths.
     """
@@ -319,6 +319,12 @@ def roles_dict(path, repo_prefix=""):
 
     roles = os.walk(path).next()[1]
 
+    # First scan all directories
+    for role in roles:
+        for sub_role in roles_dict(path + "/" + role, repo_prefix="", repo_sub_dir=role + "/"):
+            aggregated_roles[role + "/" + sub_role] = role + "/" + sub_role
+
+    # Then format them
     for role in roles:
         if is_role(os.path.join(path, role)):
             if isinstance(role, basestring):
@@ -327,7 +333,6 @@ def roles_dict(path, repo_prefix=""):
                 aggregated_roles[role] = role_repo
 
     return aggregated_roles
-
 
 def role_name(role):
     """

--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -321,7 +321,8 @@ def roles_dict(path, repo_prefix="", repo_sub_dir=""):
 
     # First scan all directories
     for role in roles:
-        for sub_role in roles_dict(path + "/" + role, repo_prefix="", repo_sub_dir=role + "/"):
+        for sub_role in roles_dict(path + "/" + role, repo_prefix="",
+                                   repo_sub_dir=role + "/"):
             aggregated_roles[role + "/" + sub_role] = role + "/" + sub_role
 
     # Then format them
@@ -333,6 +334,7 @@ def roles_dict(path, repo_prefix="", repo_sub_dir=""):
                 aggregated_roles[role] = role_repo
 
     return aggregated_roles
+
 
 def role_name(role):
     """


### PR DESCRIPTION
This PR allow to scan role structured in sub dir like this:

```
jdk
  common
    defaults
      main.yml
  install
    meta
      main.yml
    tasks
      main.yml
```
