### PR TITLE
Added use to default_format_gendoc config token

### DIFF
--- a/ansigenome/scan.py
+++ b/ansigenome/scan.py
@@ -24,7 +24,7 @@ class Scan(object):
         self.export = export
 
         # set the readme output format
-        self.readme_format = c.ALLOWED_GENDOC_FORMATS[0]
+        self.readme_format = config["default_format_gendoc"]
 
         self.roles = utils.roles_dict(self.roles_path, "")
 

--- a/ansigenome/scan.py
+++ b/ansigenome/scan.py
@@ -45,7 +45,7 @@ class Scan(object):
         # only load and validate the readme when generating docs
         if self.gendoc:
             # only change the format if it is different than the default
-            if not self.options.format == self.readme_format:
+            if self.options.format is not None:
                 self.readme_format = self.options.format
 
             extend_path = self.config["options_readme_template"]

--- a/bin/ansigenome
+++ b/bin/ansigenome
@@ -73,7 +73,6 @@ def build_option_parser(action):
         parser.set_usage("{0} ROLES_PATH [-f FORMAT]".format(usage_prefix))
         parser.add_option("-f", "--format",
                           dest="format",
-                          default="rst",
                           help="output formats: rst | md")
     elif action == "genmeta":
         parser.set_usage("{0} ROLES_PATH".format(usage_prefix))


### PR DESCRIPTION
Slight modifications to set the default documentation format to be the one found in the config file, rather than always being RST