### PR TITLE
role without yml files isn't role

### DIFF
--- a/ansigenome/utils.py
+++ b/ansigenome/utils.py
@@ -13,6 +13,8 @@ import yaml
 from jinja2 import DictLoader
 from jinja2.environment import Environment
 
+import glob
+
 import constants as c
 import ui as ui
 
@@ -353,7 +355,8 @@ def is_role(path):
     seems_legit = False
     for folder in c.ANSIBLE_FOLDERS:
         if os.path.exists(os.path.join(path, folder)):
-            seems_legit = True
+            if glob.glob(os.path.join(path, folder, "*yml")):
+                seems_legit = True
 
     return seems_legit
 


### PR DESCRIPTION
This fixes false positive checks on roles.
ex:
I have some static files in my role (this are nagios static files), so i have role:
nagios/tasks/main.yml
nagios/files/static/commands/something.cfg
nagios/files/static/templates/my_templates.cfg
nagios/files/static/services/services.cfg

and ansigenome finds template folder in my static, and add role nagios-files-static to graph... this isn't role.
So, I fixed it, but add conditional, that if folder contains yml file, that means that is role